### PR TITLE
glusterfs 9.6 for xcpng8.3

### DIFF
--- a/SOURCES/glusterfs-9.4.tar.gz
+++ b/SOURCES/glusterfs-9.4.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07f360c9b43cb1101a857706494e310328e9d6a4e6b2f0697a3bc3f165c2652a
-size 8173625

--- a/SOURCES/glusterfs-9.6.tar.gz
+++ b/SOURCES/glusterfs-9.6.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55ebe404ca887e387b1b6ecf952400f795be275f475295014dfc7ad4c1ed1464
+size 8181065

--- a/SPECS/glusterfs.spec
+++ b/SPECS/glusterfs.spec
@@ -13,7 +13,7 @@
 
 # asan
 # if you wish to compile an rpm with address sanitizer...
-# rpmbuild -ta glusterfs-9.4.tar.gz --with asan
+# rpmbuild -ta glusterfs-9.6.tar.gz --with asan
 %{?_with_asan:%global _with_asan --enable-asan}
 
 %if ( 0%{?rhel} && 0%{?rhel} < 7 )
@@ -22,42 +22,42 @@
 
 # cmocka
 # if you wish to compile an rpm with cmocka unit testing...
-# rpmbuild -ta glusterfs-9.4.tar.gz --with cmocka
+# rpmbuild -ta glusterfs-9.6.tar.gz --with cmocka
 %{?_with_cmocka:%global _with_cmocka --enable-cmocka}
 
 # debug
 # if you wish to compile an rpm with debugging...
-# rpmbuild -ta glusterfs-9.4.tar.gz --with debug
+# rpmbuild -ta glusterfs-9.6.tar.gz --with debug
 %{?_with_debug:%global _with_debug --enable-debug}
 
 # epoll
 # if you wish to compile an rpm without epoll...
-# rpmbuild -ta glusterfs-9.4.tar.gz --without epoll
+# rpmbuild -ta glusterfs-9.6.tar.gz --without epoll
 %{?_without_epoll:%global _without_epoll --disable-epoll}
 
 # fusermount
 # if you wish to compile an rpm without fusermount...
-# rpmbuild -ta glusterfs-9.4.tar.gz --without fusermount
+# rpmbuild -ta glusterfs-9.6.tar.gz --without fusermount
 %{?_without_fusermount:%global _without_fusermount --disable-fusermount}
 
 # geo-rep
 # if you wish to compile an rpm without geo-replication support, compile like this...
-# rpmbuild -ta glusterfs-9.4.tar.gz --without georeplication
+# rpmbuild -ta glusterfs-9.6.tar.gz --without georeplication
 %{?_without_georeplication:%global _without_georeplication --disable-georeplication}
 
 # gnfs
 # if you wish to compile an rpm with the legacy gNFS server xlator
-# rpmbuild -ta glusterfs-9.4.tar.gz --with gnfs
+# rpmbuild -ta glusterfs-9.6.tar.gz --with gnfs
 %{?_with_gnfs:%global _with_gnfs --enable-gnfs}
 
 # ipv6default
 # if you wish to compile an rpm with IPv6 default...
-# rpmbuild -ta glusterfs-9.4.tar.gz --with ipv6default
+# rpmbuild -ta glusterfs-9.6.tar.gz --with ipv6default
 %{?_with_ipv6default:%global _with_ipv6default --with-ipv6-default}
 
 # linux-io_uring
 # If you wish to compile an rpm without linux-io_uring support...
-# rpmbuild -ta  glusterfs-9.4.tar.gz --disable-linux-io_uring
+# rpmbuild -ta  glusterfs-9.6.tar.gz --disable-linux-io_uring
 %{?_without_linux_io_uring:%global _without_linux_io_uring --disable-linux-io_uring}
 
 # Disable linux-io_uring on unsupported distros.
@@ -67,7 +67,7 @@
 
 # libtirpc
 # if you wish to compile an rpm without TIRPC (i.e. use legacy glibc rpc)
-# rpmbuild -ta glusterfs-9.4.tar.gz --without libtirpc
+# rpmbuild -ta glusterfs-9.6.tar.gz --without libtirpc
 %{?_without_libtirpc:%global _without_libtirpc --without-libtirpc}
 
 # Do not use libtirpc on EL6, it does not have xdr_uint64_t() and xdr_uint32_t
@@ -79,12 +79,12 @@
 
 # ocf
 # if you wish to compile an rpm without the OCF resource agents...
-# rpmbuild -ta glusterfs-9.4.tar.gz --without ocf
+# rpmbuild -ta glusterfs-9.6.tar.gz --without ocf
 %{?_without_ocf:%global _without_ocf --without-ocf}
 
 # server
 # if you wish to build rpms without server components, compile like this
-# rpmbuild -ta glusterfs-9.4.tar.gz --without server
+# rpmbuild -ta glusterfs-9.6.tar.gz --without server
 %{?_without_server:%global _without_server --without-server}
 
 # disable server components forcefully as rhel <= 6
@@ -94,7 +94,7 @@
 
 # syslog
 # if you wish to build rpms without syslog logging, compile like this
-# rpmbuild -ta glusterfs-9.4.tar.gz --without syslog
+# rpmbuild -ta glusterfs-9.6.tar.gz --without syslog
 %{?_without_syslog:%global _without_syslog --disable-syslog}
 
 # disable syslog forcefully as rhel <= 6 doesn't have rsyslog or rsyslog-mmcount
@@ -107,7 +107,7 @@
 
 # tsan
 # if you wish to compile an rpm with thread sanitizer...
-# rpmbuild -ta glusterfs-9.4.tar.gz --with tsan
+# rpmbuild -ta glusterfs-9.6.tar.gz --with tsan
 %{?_with_tsan:%global _with_tsan --enable-tsan}
 
 %if ( 0%{?rhel} && 0%{?rhel} < 7 )
@@ -116,7 +116,7 @@
 
 # valgrind
 # if you wish to compile an rpm to run all processes under valgrind...
-# rpmbuild -ta glusterfs-9.4.tar.gz --with valgrind
+# rpmbuild -ta glusterfs-9.6.tar.gz --with valgrind
 %{?_with_valgrind:%global _with_valgrind --enable-valgrind}
 
 ##-----------------------------------------------------------------------------
@@ -153,7 +153,7 @@
 %global _without_ocf --without-ocf
 %endif
 
-%if ( 0%{?fedora} ) || ( 0%{?rhel} && 0%{?rhel} > 7 )
+%if ( 0%{?fedora} ) || ( 0%{?rhel} && 0%{?rhel} > 7 || 0%{?xenserver} >= 8)
 %global _usepython3 1
 %global _pythonver 3
 %else
@@ -229,8 +229,8 @@ Version:          3.8.0
 Release:          0.1%{?prereltag:.%{prereltag}}%{?dist}
 %else
 Name:             glusterfs
-Version:          9.4
-Release:          2%{?dist}
+Version:          9.6
+Release:          1%{?dist}
 %endif
 License:          GPLv2 or LGPLv3+
 URL:              http://docs.gluster.org/
@@ -241,7 +241,7 @@ Source2:          glusterfsd.sysconfig
 Source7:          glusterfsd.service
 Source8:          glusterfsd.init
 %else
-Source0:          glusterfs-9.4.tar.gz
+Source0:          glusterfs-9.6.tar.gz
 %endif
 
 BuildRoot:        %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
@@ -1642,6 +1642,10 @@ exit 0
 %endif
 
 %changelog
+* Fri Feb 02 2023 Yann Dirson <yann.dirson@vates.tech> - 9.6-1
+- Update to version 9.6
+- Force using python3 on 8.3
+
 * Fri Sep 30 2022 Samuel Verschelde <stormi-xcp@ylix.fr> - 9.4-2
 - Rebuild for XCP-ng 8.3
 


### PR DESCRIPTION
Introduces a vendor branch to more clearly track our changes from upstream.
Forces use of python3 on 8.3 (using the fact that `xenserver` macro is not defined on 8.2)